### PR TITLE
Update github.com/unknwon/com imports

### DIFF
--- a/cmd/analogy.go
+++ b/cmd/analogy.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/Unknwon/com"
-	"github.com/k0kubun/pp"
 	fasttext "github.com/bountylabs/go-fasttext"
+	"github.com/k0kubun/pp"
 	"github.com/spf13/cobra"
+	"github.com/unknwon/com"
 )
 
 var (

--- a/cmd/predict.go
+++ b/cmd/predict.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/Unknwon/com"
-	"github.com/k0kubun/pp"
 	fasttext "github.com/bountylabs/go-fasttext"
+	"github.com/k0kubun/pp"
 	"github.com/spf13/cobra"
+	"github.com/unknwon/com"
 )
 
 var (

--- a/cmd/sentence.go
+++ b/cmd/sentence.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/Unknwon/com"
-	"github.com/k0kubun/pp"
 	fasttext "github.com/bountylabs/go-fasttext"
+	"github.com/k0kubun/pp"
 	"github.com/spf13/cobra"
+	"github.com/unknwon/com"
 )
 
 // predictCmd represents the predict command
@@ -35,6 +35,6 @@ var sentenceCmd = &cobra.Command{
 }
 
 func init() {
-  sentenceCmd.Flags().StringVarP(&modelPath, "model", "m", "", "path to the fasttext model")
+	sentenceCmd.Flags().StringVarP(&modelPath, "model", "m", "", "path to the fasttext model")
 	rootCmd.AddCommand(sentenceCmd)
 }

--- a/cmd/wordvec.go
+++ b/cmd/wordvec.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/Unknwon/com"
-	"github.com/k0kubun/pp"
 	fasttext "github.com/bountylabs/go-fasttext"
+	"github.com/k0kubun/pp"
 	"github.com/spf13/cobra"
+	"github.com/unknwon/com"
 )
 
 // var (


### PR DESCRIPTION
This module recently changed the case of the path it's published under. Importing it under the former path (`github.com/Unknwon/com`) is incompatible with module-based builds in the service repo.

More details: https://github.com/golang/go/wiki/Modules#how-can-i-resolve-parsing-gomod-unexpected-module-path-and-error-loading-module-requirements-errors-caused-by-a-mismatch-between-import-paths-vs-declared-module-identity

Upstream commit introducing the module path change: https://github.com/unknwon/com/commit/a5e912522a8b6364ff3f954a03321e60f6b08219